### PR TITLE
Fix reuse not being received as boolean

### DIFF
--- a/kutt/kutt.py
+++ b/kutt/kutt.py
@@ -7,7 +7,8 @@ def submit(apikey, url, description=None, expire_in=None, password=None, customu
     """Create a new shorten url object"""
     headers = {'X-API-Key': apikey}
 
-    payload = json.dumps({'target': url, 'description' : description, 'expire_in' : expire_in, 'password' : password, 'customurl' : customurl, 'reuse' : reuse, 'domain' : domain})
+    payload = {'target': url, 'description' : description, 'expire_in' : expire_in, 'password' : password, 'customurl' : customurl, 'reuse' : json.dumps(reuse), 'domain' : domain}
+    print(payload)
     res = requests.post(host_url, data=payload, headers=headers)
 
     data = res.json()

--- a/kutt/kutt.py
+++ b/kutt/kutt.py
@@ -1,13 +1,13 @@
 """Kutt.it API wrapper"""
 import requests
-
+import json
 BASE_URL = "https://kutt.it/api/v2/links"
 
 def submit(apikey, url, description=None, expire_in=None, password=None, customurl=None, reuse=False, domain=None, host_url=BASE_URL):
     """Create a new shorten url object"""
     headers = {'X-API-Key': apikey}
 
-    payload = {'target': url, 'description' : description, 'expire_in' : expire_in, 'password' : password, 'customurl' : customurl, 'reuse' : reuse, 'domain' : domain}
+    payload = json.dumps({'target': url, 'description' : description, 'expire_in' : expire_in, 'password' : password, 'customurl' : customurl, 'reuse' : reuse, 'domain' : domain})
     res = requests.post(host_url, data=payload, headers=headers)
 
     data = res.json()


### PR DESCRIPTION
Hi there,

I just deployed kutt and when using the python library I noticed there was an issue with the `reuse` argument being sent to the API in the `submit` function. I guess this is link to this issue, some conflict between capital `True` (Python) and lowercase `true` (JS) when `requests` sends the payload : https://stackoverflow.com/questions/17980362/using-python-requests-to-send-json-boolean

With this fix it made it work on my side.